### PR TITLE
refactor(Issue): improve `isFlagged` assignment

### DIFF
--- a/src/components/Issue.tsx
+++ b/src/components/Issue.tsx
@@ -8,15 +8,10 @@ import IssueTransitions from './IssueTransitions'
 export default function Issue({issue, skip = false, dark = false}) {
   const [isOpen, setIsOpen] = React.useState(false)
   const {hostUrl} = useJira()
-
-  let isFlagged = false
-  if (issue.fields['customfield_10021']) {
-    isFlagged = Boolean(
-      issue.fields['customfield_10021'].some(
-        (field) => field.value === 'Impediment',
-      ),
-    )
-  }
+  const isFlagged =
+    issue.fields['customfield_10021']?.some(
+      (field) => field.value === 'Impediment',
+    ) || false
 
   return (
     <details


### PR DESCRIPTION
- `Array.prototype.some()` already returns a boolean, so no need to cast it again
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some#return_value
- Optional chaining let's you assign the value directly instead of needing an `if`-statement